### PR TITLE
<dir> tags are required for v20 (Nexus)

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,9 +4,11 @@
 		<import addon="xbmc.addon" version="12.0.0"/>
 	</requires>
 	<extension point="xbmc.addon.repository" name="PlexKodiConnect Repository">
-		<info compressed="false">https://github.com/croneter/repository.plexkodiconnect/repo/addons.xml</info>
-		<checksum>https://github.com/croneter/repository.plexkodiconnect/repo/addons.xml.md5</checksum>
-		<datadir zip="true">https://github.com/croneter/repository.plexkodiconnect/repo/bin/</datadir>
+        <dir>
+		    <info compressed="false">https://github.com/croneter/repository.plexkodiconnect/repo/addons.xml</info>
+		    <checksum>https://github.com/croneter/repository.plexkodiconnect/repo/addons.xml.md5</checksum>
+            <datadir zip="true">https://github.com/croneter/repository.plexkodiconnect/repo/bin/</datadir>
+        </dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>PlexKodiConnect Addon Repository</summary>


### PR DESCRIPTION
related to https://github.com/croneter/PlexKodiConnect/issues/1844#issuecomment-1216756233 and requested by @bokkoman 

Kodi v20 shows the following in the log when trying to access the repo, after installation

```
ERROR <general>: Repository add-on repository.plexkodiconnect does not have any directory and won't be able to update/serve addons! Please fix the addon.xml definition

ERROR <general>: Repository add-on repository.plexkodiconnect uses old schema definition for the repository extension point! This is no longer supported, please update your addon to use <dir> definitions.
```